### PR TITLE
fix: crash when err.originalError is unset

### DIFF
--- a/src/server/routes/graphql.js
+++ b/src/server/routes/graphql.js
@@ -18,7 +18,7 @@ const executableSchema = makeExecutableSchema({
 
 const formatError = err => {
   // node-postgres does not use an Error subclass so we check for schema property
-  if (err.originalError.hasOwnProperty("schema") && config.isProduction) {
+  if (err.originalError && err.originalError.hasOwnProperty("schema") && config.isProduction) {
     logger.error("Postgres error: ", err);
     return new Error("Internal server error");
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If `err.originalError` is unset in the graphql error formatting, the server returns an error response without any information useful for debugging the original error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Report the initial error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation Changes
<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
